### PR TITLE
Added mapstruct mapper for product resource

### DIFF
--- a/app/src/test/java/it/pagopa/selfcare/product/web/config/SwaggerConfigTest.java
+++ b/app/src/test/java/it/pagopa/selfcare/product/web/config/SwaggerConfigTest.java
@@ -2,6 +2,7 @@ package it.pagopa.selfcare.product.web.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import it.pagopa.selfcare.product.core.ProductService;
+import it.pagopa.selfcare.product.web.model.mapper.ProductResourceMapperImpl;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -25,7 +26,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest(classes = {
         SwaggerConfig.class,
-        WebConfig.class
+        WebConfig.class,
+        ProductResourceMapperImpl.class
 })
 @EnableOpenApi
 @EnableWebMvc

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>it.pagopa.selfcare</groupId>
         <artifactId>selc-starter-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>0.0.2-SNAPSHOT</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <artifactId>selc-product</artifactId>

--- a/web/src/main/java/it/pagopa/selfcare/product/web/controller/ProductController.java
+++ b/web/src/main/java/it/pagopa/selfcare/product/web/controller/ProductController.java
@@ -9,7 +9,7 @@ import it.pagopa.selfcare.product.connector.model.ProductOperations;
 import it.pagopa.selfcare.product.connector.model.ProductStatus;
 import it.pagopa.selfcare.product.core.ProductService;
 import it.pagopa.selfcare.product.web.model.*;
-import it.pagopa.selfcare.product.web.model.mapper.ProductMapper;
+import it.pagopa.selfcare.product.web.model.mapper.ProductResourceMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -32,11 +32,12 @@ import java.util.stream.Collectors;
 public class ProductController {
 
     private final ProductService productService;
-
+    private final ProductResourceMapper productResourceMapper;
 
     @Autowired
-    public ProductController(ProductService productService) {
+    public ProductController(ProductService productService, ProductResourceMapper productResourceMapper) {
         this.productService = productService;
+        this.productResourceMapper = productResourceMapper;
     }
 
 
@@ -47,7 +48,7 @@ public class ProductController {
         log.trace("getProducts start");
         List<ProductOperations> products = productService.getProducts(true);
         List<ProductResource> productResources = products.stream()
-                .map(ProductMapper::toResource)
+                .map(productResourceMapper::toResource)
                 .collect(Collectors.toList());
         log.debug("getProducts result = {}", productResources);
         log.trace("getProducts end");
@@ -61,7 +62,7 @@ public class ProductController {
     public List<ProductTreeResource> getProductsTree() {
         log.trace("getProductsTree start");
         List<ProductOperations> products = productService.getProducts(false);
-        List<ProductTreeResource> result = ProductMapper.toTreeResource(products);
+        List<ProductTreeResource> result = productResourceMapper.toTreeResource(products);
         log.debug("getProductsTree result = {}", result);
         log.trace("getProductsTree end");
         return result;
@@ -109,7 +110,7 @@ public class ProductController {
         log.trace("getProduct start");
         log.debug("getProduct id = {}, institutionType = {}", id, institutionType);
         ProductOperations product = productService.getProduct(id, institutionType.orElse(null));
-        ProductResource productResource = ProductMapper.toResource(product);
+        ProductResource productResource = productResourceMapper.toResource(product);
         log.debug("getProduct result = {}", productResource);
         log.trace("getProduct end");
         return productResource;
@@ -123,7 +124,7 @@ public class ProductController {
                                                            String id) {
         log.trace("getProductRoles start");
         log.debug("getProductRoles id = {}", id);
-        EnumMap<PartyRole, ProductRoleInfo> productRoles = ProductMapper.toRoleMappings(productService.getProduct(id, null).getRoleMappings());
+        EnumMap<PartyRole, ProductRoleInfo> productRoles = ProductResourceMapper.toRoleMappings(productService.getProduct(id, null).getRoleMappings());
         log.debug("getProductRoles result = {}", productRoles);
         log.trace("getProductRoles end");
 
@@ -139,8 +140,8 @@ public class ProductController {
                                          CreateProductDto product) {
         log.trace("createProduct start");
         log.debug("createProduct product = {}", product);
-        ProductOperations p = productService.createProduct(ProductMapper.fromDto(product));
-        ProductResource createdProduct = ProductMapper.toResource(p);
+        ProductOperations p = productService.createProduct(productResourceMapper.fromDto(product));
+        ProductResource createdProduct = productResourceMapper.toResource(p);
         log.debug("createProduct result = {}", createdProduct);
         log.trace("createProduct end");
         return createdProduct;
@@ -157,10 +158,10 @@ public class ProductController {
                                             CreateSubProductDto product) {
         log.trace("createProduct start");
         log.debug("createProduct product = {}", product);
-        ProductOperations productOps = ProductMapper.fromDto(product);
+        ProductOperations productOps = productResourceMapper.fromDto(product);
         productOps.setParentId(id);
         ProductOperations p = productService.createProduct(productOps);
-        ProductResource createdProduct = ProductMapper.toResource(p);
+        ProductResource createdProduct = productResourceMapper.toResource(p);
         log.debug("createProduct result = {}", createdProduct);
         log.trace("createProduct end");
         return createdProduct;
@@ -178,8 +179,8 @@ public class ProductController {
                                          UpdateProductDto product) {
         log.trace("updateProduct start");
         log.debug("updateProduct id = {}, product = {}", id, product);
-        ProductOperations updatedProduct = productService.updateProduct(id, ProductMapper.fromDto(product));
-        ProductResource result = ProductMapper.toResource(updatedProduct);
+        ProductOperations updatedProduct = productService.updateProduct(id, productResourceMapper.fromDto(product));
+        ProductResource result = productResourceMapper.toResource(updatedProduct);
         log.debug("updateProduct result = {}", result);
         log.trace("updateProduct end");
         return result;
@@ -196,8 +197,8 @@ public class ProductController {
                                                 UpdateSubProductDto product) {
         log.trace("updateSubProduct start");
         log.debug("updateSubProduct id = {}, product = {}", id, product);
-        ProductOperations updatedProduct = productService.updateProduct(id, ProductMapper.fromDto(product));
-        ProductResource result = ProductMapper.toResource(updatedProduct);
+        ProductOperations updatedProduct = productService.updateProduct(id, productResourceMapper.fromDto(product));
+        ProductResource result = productResourceMapper.toResource(updatedProduct);
         log.debug("updateSubProduct result = {}", result);
         log.trace("updateSubProduct end");
         return result;

--- a/web/src/main/java/it/pagopa/selfcare/product/web/model/mapper/ProductMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/product/web/model/mapper/ProductMapper.java
@@ -10,6 +10,10 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.*;
 import java.util.stream.Collectors;
 
+/**
+ * It's better using sdk such as <a href="https://reflectoring.io/java-mapping-with-mapstruct/">mapstruct</a>, look at @classes ProductResourceMapper
+ * */
+@Deprecated
 @Slf4j
 public class ProductMapper {
 

--- a/web/src/main/java/it/pagopa/selfcare/product/web/model/mapper/ProductResourceMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/product/web/model/mapper/ProductResourceMapper.java
@@ -1,0 +1,122 @@
+package it.pagopa.selfcare.product.web.model.mapper;
+
+import it.pagopa.selfcare.product.connector.model.BackOfficeConfigurations;
+import it.pagopa.selfcare.product.connector.model.PartyRole;
+import it.pagopa.selfcare.product.connector.model.ProductOperations;
+import it.pagopa.selfcare.product.connector.model.ProductRoleInfoOperations;
+import it.pagopa.selfcare.product.web.model.*;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.springframework.util.StringUtils;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Mapper(componentModel = "spring")
+public interface ProductResourceMapper {
+
+    @Mapping(source = "modifiedBy", target = "modifiedBy", qualifiedByName = "getUserUUID")
+    @Mapping(source = "createdBy", target = "createdBy", qualifiedByName = "getUserUUID")
+    @Mapping(source = "backOfficeEnvironmentConfigurations", target = "backOfficeEnvironmentConfigurations", qualifiedByName = "toBackOfficeConfigurations")
+    @Mapping(source = "roleMappings", target = "roleMappings", qualifiedByName = "toRoleMappings")
+    ProductResource toResource(ProductOperations entity);
+
+    @Mapping(source = "id", target = "id")
+    @Mapping(source = "title", target = "title")
+    @Mapping(source = "identityTokenAudience", target = "identityTokenAudience")
+    @Mapping(source = "logoBgColor", target = "logoBgColor")
+    @Mapping(source = "description", target = "description")
+    @Mapping(source = "roleMappings", target = "roleMappings", qualifiedByName = "toRoleMappings")
+    @Mapping(source = "urlBO", target = "urlBO")
+    @Mapping(source = "urlPublic", target = "urlPublic")
+    @Mapping(source = "contractTemplatePath", target = "contractTemplatePath")
+    @Mapping(source = "contractTemplateVersion", target = "contractTemplateVersion")
+    @Mapping(source = "institutionContractMappings", target = "institutionContractMappings")
+    @Mapping(source = "backOfficeEnvironmentConfigurations", target = "backOfficeEnvironmentConfigurations")
+    ProductDto fromDto(CreateProductDto dto);
+
+    @Mapping(source = "id", target = "id")
+    @Mapping(source = "title", target = "title")
+    @Mapping(source = "contractTemplatePath", target = "contractTemplatePath")
+    @Mapping(source = "contractTemplateVersion", target = "contractTemplateVersion")
+    @Mapping(source = "institutionContractMappings", target = "institutionContractMappings")
+    ProductDto fromDto(CreateSubProductDto dto);
+
+    @Mapping(source = "title", target = "title")
+    @Mapping(source = "identityTokenAudience", target = "identityTokenAudience")
+    @Mapping(source = "logoBgColor", target = "logoBgColor")
+    @Mapping(source = "description", target = "description")
+    @Mapping(source = "roleMappings", target = "roleMappings", qualifiedByName = "toRoleMappings")
+    @Mapping(source = "urlBO", target = "urlBO")
+    @Mapping(source = "urlPublic", target = "urlPublic")
+    @Mapping(source = "contractTemplatePath", target = "contractTemplatePath")
+    @Mapping(source = "contractTemplateVersion", target = "contractTemplateVersion")
+    @Mapping(source = "institutionContractMappings", target = "institutionContractMappings")
+    @Mapping(source = "backOfficeEnvironmentConfigurations", target = "backOfficeEnvironmentConfigurations")
+    ProductDto fromDto(UpdateProductDto dto);
+
+    @Mapping(source = "title", target = "title")
+    @Mapping(source = "contractTemplatePath", target = "contractTemplatePath")
+    @Mapping(source = "contractTemplateVersion", target = "contractTemplateVersion")
+    @Mapping(source = "institutionContractMappings", target = "institutionContractMappings")
+    ProductDto fromDto(UpdateSubProductDto dto);
+
+    @Named("toBackOfficeConfigurations")
+    static Map<String, BackOfficeConfigurationsResource> toBackOfficeConfigurations(Map<String, ? extends BackOfficeConfigurations> backOfficeConfigurations) {
+        Map<String, BackOfficeConfigurationsResource> result;
+        if (backOfficeConfigurations == null) {
+            result = null;
+        } else {
+            result = new HashMap<>();
+            backOfficeConfigurations.forEach((key, value) -> {
+                final BackOfficeConfigurationsResource resource = new BackOfficeConfigurationsResource();
+                resource.setUrl(value.getUrl());
+                resource.setIdentityTokenAudience(value.getIdentityTokenAudience());
+                result.put(key, resource);
+            });
+        }
+        return result;
+    }
+
+    @Named("toRoleMappings")
+    static EnumMap<PartyRole, ProductRoleInfo> toRoleMappings(EnumMap<PartyRole, ? extends ProductRoleInfoOperations> roleMappings) {
+        EnumMap<PartyRole, ProductRoleInfo> result;
+        if (roleMappings == null) {
+            result = null;
+        } else {
+            result = new EnumMap<>(PartyRole.class);
+            roleMappings.forEach((key, value) -> result.put(key, new ProductRoleInfo(value)));
+        }
+        return result;
+    }
+
+    @Named("getUserUUID")
+    static UUID getUserUUID(String user) {
+        if(StringUtils.hasText(user))
+            return UUID.fromString(user);
+        return null;
+    }
+
+    default List<ProductTreeResource> toTreeResource(List<ProductOperations> model) {
+        List<ProductTreeResource> resources = null;
+        if (model != null) {
+            Map<String, List<ProductOperations>> collect = model.stream()
+                    .filter(productOperations -> productOperations.getParentId() != null)
+                    .collect(Collectors.groupingBy(ProductOperations::getParentId, Collectors.toList()));
+            resources = model.stream()
+                    .filter(productOperations -> productOperations.getParentId() == null)
+                    .map(productOperations -> {
+                        ProductTreeResource productTreeResource = new ProductTreeResource();
+                        productTreeResource.setNode(this.toResource(productOperations));
+                        if (collect.get(productOperations.getId()) != null) {
+                            productTreeResource.setChildren(collect.get(productOperations.getId()).stream()
+                                    .map(this::toResource)
+                                    .collect(Collectors.toList()));
+                        }
+                        return productTreeResource;
+                    }).collect(Collectors.toList());
+        }
+        return resources;
+    }
+}

--- a/web/src/test/java/it/pagopa/selfcare/product/web/controller/ProductControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/product/web/controller/ProductControllerTest.java
@@ -12,6 +12,7 @@ import it.pagopa.selfcare.product.core.ProductService;
 import it.pagopa.selfcare.product.web.config.WebTestConfig;
 import it.pagopa.selfcare.product.web.handler.ProductExceptionsHandler;
 import it.pagopa.selfcare.product.web.model.*;
+import it.pagopa.selfcare.product.web.model.mapper.ProductResourceMapperImpl;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -49,8 +50,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ContextConfiguration(classes = {
         ProductController.class,
         ProductExceptionsHandler.class,
-        WebTestConfig.class
-})
+        WebTestConfig.class,
+        ProductResourceMapperImpl.class})
 class ProductControllerTest {
 
     private static final String BASE_URL = "/products";


### PR DESCRIPTION
#### List of Changes

Added mapstruct mapper in substitution of previous custom one.

#### Motivation and Context

It has been decided to change mappers and use mapstruct library. This approach should reduce verbosity of code and help maintainability of software.

#### How Has This Been Tested?

I have run microservice ms-product locally aiming to dev environment. Through Swagger, i have tried all api calls and compared responses with the same from branch release-dev. 

#### Screenshots (if appropriate):

Attached to this PR, there are files used to compare response objects (files marked with "mapper" are objects obtained after using mapstruct)

[checks.zip](https://github.com/pagopa/selfcare-ms-product/files/11959059/checks.zip)
