### PR TITLE
[SELC - 3049] added new api to verify if product is valid or not

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -876,10 +876,95 @@
           "bearerAuth" : [ "global" ]
         } ]
       }
+    },
+    "/products/{id}/valid" : {
+      "get" : {
+        "tags" : [ "product" ],
+        "summary" : "getProductIsValid",
+        "description" : "Service that returns the information for a single product given its product id",
+        "operationId" : "getProductIsValidUsingGET",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "description" : "Product's unique identifier",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProductResource"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
     }
   },
   "components" : {
     "schemas" : {
+      "BackOfficeConfigurations" : {
+        "title" : "BackOfficeConfigurations",
+        "type" : "object",
+        "properties" : {
+          "identityTokenAudience" : {
+            "type" : "string"
+          },
+          "url" : {
+            "type" : "string"
+          }
+        }
+      },
       "BackOfficeConfigurationsResource" : {
         "title" : "BackOfficeConfigurationsResource",
         "required" : [ "identityTokenAudience", "url" ],
@@ -892,6 +977,22 @@
           "url" : {
             "type" : "string",
             "description" : "URL that redirects to the back-office section, where is possible to manage the product"
+          }
+        }
+      },
+      "ContractOperations" : {
+        "title" : "ContractOperations",
+        "type" : "object",
+        "properties" : {
+          "contractTemplatePath" : {
+            "type" : "string"
+          },
+          "contractTemplateUpdatedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "contractTemplateVersion" : {
+            "type" : "string"
           }
         }
       },
@@ -1062,6 +1163,100 @@
         },
         "description" : "A \"problem detail\" as a way to carry machine-readable details of errors (https://datatracker.ietf.org/doc/html/rfc7807)"
       },
+      "ProductOperations" : {
+        "title" : "ProductOperations",
+        "type" : "object",
+        "properties" : {
+          "backOfficeEnvironmentConfigurations" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "$ref" : "#/components/schemas/BackOfficeConfigurations"
+            }
+          },
+          "contractTemplatePath" : {
+            "type" : "string"
+          },
+          "contractTemplateUpdatedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "contractTemplateVersion" : {
+            "type" : "string"
+          },
+          "createdAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "createdBy" : {
+            "type" : "string"
+          },
+          "delegable" : {
+            "type" : "boolean"
+          },
+          "depictImageUrl" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "enabled" : {
+            "type" : "boolean"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "identityTokenAudience" : {
+            "type" : "string"
+          },
+          "institutionContractMappings" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "$ref" : "#/components/schemas/ContractOperations"
+            }
+          },
+          "logo" : {
+            "type" : "string"
+          },
+          "logoBgColor" : {
+            "type" : "string"
+          },
+          "modifiedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "modifiedBy" : {
+            "type" : "string"
+          },
+          "parentId" : {
+            "type" : "string"
+          },
+          "productOperations" : {
+            "$ref" : "#/components/schemas/ProductOperations"
+          },
+          "roleManagementURL" : {
+            "type" : "string"
+          },
+          "roleMappings" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "$ref" : "#/components/schemas/ProductRoleInfoOperations"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "ACTIVE", "INACTIVE", "PHASE_OUT", "TESTING" ]
+          },
+          "title" : {
+            "type" : "string"
+          },
+          "urlBO" : {
+            "type" : "string"
+          },
+          "urlPublic" : {
+            "type" : "string"
+          }
+        }
+      },
       "ProductResource" : {
         "title" : "ProductResource",
         "type" : "object",
@@ -1140,6 +1335,9 @@
             "type" : "string",
             "description" : "Root parent of the sub product"
           },
+          "productOperations" : {
+            "$ref" : "#/components/schemas/ProductOperations"
+          },
           "roleManagementURL" : {
             "type" : "string",
             "description" : "Url of the utilities management"
@@ -1186,6 +1384,21 @@
           "label" : {
             "type" : "string",
             "description" : "Product role label"
+          }
+        }
+      },
+      "ProductRoleInfoOperations" : {
+        "title" : "ProductRoleInfoOperations",
+        "type" : "object",
+        "properties" : {
+          "multiroleAllowed" : {
+            "type" : "boolean"
+          },
+          "roles" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ProductRoleOperations"
+            }
           }
         }
       },

--- a/connector-api/src/main/java/it/pagopa/selfcare/product/connector/model/ProductOperations.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/product/connector/model/ProductOperations.java
@@ -101,4 +101,7 @@ public interface ProductOperations {
 
     void setDelegable(boolean delegable);
 
+    ProductOperations getProductOperations();
+
+    void setProductOperations(ProductOperations productOperations);
 }

--- a/connector-api/src/test/java/it/pagopa/selfcare/product/connector/model/DummyProduct.java
+++ b/connector-api/src/test/java/it/pagopa/selfcare/product/connector/model/DummyProduct.java
@@ -33,5 +33,16 @@ public class DummyProduct implements ProductOperations {
     private String parentId;
     private Map<String, ? extends BackOfficeConfigurations> backOfficeEnvironmentConfigurations;
     private String roleManagementURL;
+    private ProductOperations productOperations;
 
+
+    @Override
+    public ProductOperations getProductOperations() {
+        return productOperations;
+    }
+
+    @Override
+    public void setProductOperations(ProductOperations productOperations) {
+        this.productOperations = productOperations;
+    }
 }

--- a/connector/dao/src/main/java/it/pagopa/selfcare/product/connector/dao/model/ProductEntity.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/product/connector/dao/model/ProductEntity.java
@@ -57,6 +57,17 @@ public class ProductEntity implements ProductOperations, Persistable<String> {
     private Map<String, ? extends BackOfficeConfigurations> backOfficeEnvironmentConfigurations;
     @Transient
     private boolean isNew = true;
+    private ProductOperations productOperations;
+
+    @Override
+    public ProductOperations getProductOperations() {
+        return productOperations;
+    }
+
+    @Override
+    public void setProductOperations(ProductOperations productOperations) {
+        this.productOperations = productOperations;
+    }
 
 
     @Data

--- a/core/src/main/java/it/pagopa/selfcare/product/core/ProductService.java
+++ b/core/src/main/java/it/pagopa/selfcare/product/core/ProductService.java
@@ -17,6 +17,8 @@ public interface ProductService {
 
     ProductOperations getProduct(String id, InstitutionType institutionType);
 
+    ProductOperations getProductIsValid(String id);
+
     ProductOperations updateProduct(String id, ProductOperations product);
 
     void updateProductStatus(String id, ProductStatus status);

--- a/core/src/main/java/it/pagopa/selfcare/product/core/ProductServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/product/core/ProductServiceImpl.java
@@ -124,6 +124,30 @@ class ProductServiceImpl implements ProductService {
         return foundProduct;
     }
 
+    public ProductOperations getProductIsValid(String id) {
+        log.trace("getProduct start");
+        log.debug("getProduct id = {}", id);
+        Assert.hasText(id, REQUIRED_PRODUCT_ID_MESSAGE);
+        ProductOperations foundProduct = productConnector.findById(id).orElseThrow(ResourceNotFoundException::new);
+        ProductOperations baseProduct = null;
+        if (foundProduct.getParentId() != null) {
+            baseProduct = productConnector.findById(foundProduct.getParentId()).orElseThrow(ResourceNotFoundException::new);
+            if (baseProduct.getStatus() == ProductStatus.PHASE_OUT) {
+                return null;
+            } else if  (foundProduct.getStatus() != ProductStatus.PHASE_OUT){
+                foundProduct.setProductOperations(baseProduct);
+                return foundProduct;
+            }
+        } else if (foundProduct.getStatus() != ProductStatus.PHASE_OUT) {
+            return foundProduct;
+        }
+
+        log.debug("getProduct result = {}", foundProduct);
+        log.debug("getBaseProduct result = {}", baseProduct);
+        log.trace("getProduct end");
+        return null;
+    }
+
 
     @Override
     public ProductOperations updateProduct(String id, ProductOperations product) {

--- a/core/src/test/java/it/pagopa/selfcare/product/core/ProductServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/product/core/ProductServiceImplTest.java
@@ -948,5 +948,86 @@ class ProductServiceImplTest {
 
     }
 
+   @Test
+   void getProductAndBaseProductIsValid() {
+       //given
+       String productId = "prod-io-premium";
+       String baseProductId = "prod-io";
+       ProductOperations foundProduct = new DummyProduct();
+       foundProduct.setId(productId);
+       foundProduct.setStatus(ProductStatus.ACTIVE);
+       foundProduct.setParentId(baseProductId);
+       ProductOperations baseProduct = new DummyProduct();
+       baseProduct.setId(baseProductId);
+       baseProduct.setStatus(ProductStatus.ACTIVE);
+       when(productConnectorMock.findById(productId))
+               .thenReturn(Optional.of(foundProduct));
+       when(productConnectorMock.findById(baseProductId))
+               .thenReturn(Optional.of(baseProduct));
+       // when
+       ProductOperations product = productService.getProductIsValid(productId);
+       // then
+       assertNotNull(product);
+       verify(productConnectorMock, times(1)).findById(productId);
+       verify(productConnectorMock, times(1)).findById(baseProductId);
+   }
+
+    @Test
+    void getProductIsValidAndBaseProductIsNotValid() {
+        //given
+        String productId = "prod-io-premium";
+        String baseProductId = "prod-io";
+        ProductOperations foundProduct = new DummyProduct();
+        foundProduct.setId(productId);
+        foundProduct.setStatus(ProductStatus.ACTIVE);
+        foundProduct.setParentId(baseProductId);
+        ProductOperations baseProduct = new DummyProduct();
+        baseProduct.setId(baseProductId);
+        baseProduct.setStatus(ProductStatus.PHASE_OUT);
+        when(productConnectorMock.findById(productId))
+                .thenReturn(Optional.of(foundProduct));
+        when(productConnectorMock.findById(baseProductId))
+                .thenReturn(Optional.of(baseProduct));
+        // when
+        ProductOperations product = productService.getProductIsValid(productId);
+        // then
+        assertNull(product);
+        verify(productConnectorMock, times(1)).findById(productId);
+        verify(productConnectorMock, times(1)).findById(baseProductId);
+    }
+
+    @Test
+    void getProductIsValid() {
+        //given
+        String productId = "prod-io";
+        ProductOperations foundProduct = new DummyProduct();
+        foundProduct.setId(productId);
+        foundProduct.setStatus(ProductStatus.ACTIVE);
+        when(productConnectorMock.findById(productId))
+                .thenReturn(Optional.of(foundProduct));
+        // when
+        ProductOperations product = productService.getProductIsValid(productId);
+        // then
+        assertNotNull(product);
+        verify(productConnectorMock, times(1)).findById(productId);
+        verifyNoMoreInteractions(productConnectorMock);
+    }
+
+    @Test
+    void getProductIsNotValid() {
+        //given
+        String productId = "prod-io";
+        ProductOperations foundProduct = new DummyProduct();
+        foundProduct.setId(productId);
+        foundProduct.setStatus(ProductStatus.PHASE_OUT);
+        when(productConnectorMock.findById(productId))
+                .thenReturn(Optional.of(foundProduct));
+        // when
+        ProductOperations product = productService.getProductIsValid(productId);
+        // then
+        assertNull(product);
+        verify(productConnectorMock, times(1)).findById(productId);
+        verifyNoMoreInteractions(productConnectorMock);
+    }
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/product/web/controller/ProductController.java
+++ b/web/src/main/java/it/pagopa/selfcare/product/web/controller/ProductController.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -231,6 +232,21 @@ public class ProductController {
         log.debug("deleteProduct id = {}", id);
         productService.deleteProduct(id);
         log.trace("deleteProduct end");
+    }
+    @GetMapping("/{id}/valid")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation(value = "", notes = "${swagger.product.operation.getProduct}")
+    public ResponseEntity <ProductResource> getProductIsValid(@ApiParam("${swagger.product.model.id}")
+                                      @PathVariable("id")
+                                      String id) {
+        log.trace("getProduct start");
+        ProductOperations product = productService.getProductIsValid(id);
+        ProductResource productResource = productResourceMapper.toResource(product);
+        log.debug("getProduct result = {}", productResource);
+        log.trace("getProduct end");
+        if(productResource != null) {
+            return ResponseEntity.ok().body(productResource);
+        } else return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/product/web/model/ProductDto.java
+++ b/web/src/main/java/it/pagopa/selfcare/product/web/model/ProductDto.java
@@ -35,5 +35,16 @@ public class ProductDto implements ProductOperations {
     private String parentId;
     private String identityTokenAudience;
     private Map<String, ? extends BackOfficeConfigurations> backOfficeEnvironmentConfigurations;
+    private ProductOperations productOperations;
 
+
+    @Override
+    public ProductOperations getProductOperations() {
+        return productOperations;
+    }
+
+    @Override
+    public void setProductOperations(ProductOperations productOperations) {
+        this.productOperations = productOperations;
+    }
 }

--- a/web/src/main/java/it/pagopa/selfcare/product/web/model/ProductResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/product/web/model/ProductResource.java
@@ -2,6 +2,7 @@ package it.pagopa.selfcare.product.web.model;
 
 import io.swagger.annotations.ApiModelProperty;
 import it.pagopa.selfcare.product.connector.model.PartyRole;
+import it.pagopa.selfcare.product.connector.model.ProductOperations;
 import it.pagopa.selfcare.product.connector.model.ProductStatus;
 import lombok.Data;
 
@@ -79,4 +80,5 @@ public class ProductResource {
     @ApiModelProperty(value = "${swagger.product.model.roleManagementURL}")
     private String roleManagementURL;
 
+    private ProductOperations productOperations;
 }

--- a/web/src/test/java/it/pagopa/selfcare/product/web/controller/ProductControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/product/web/controller/ProductControllerTest.java
@@ -537,5 +537,67 @@ class ProductControllerTest {
 
     }
 
+    @Test
+    void getProductIsValid() throws Exception {
+
+        String id = "prod-io-premium";
+
+        ProductOperations product = new ProductDto();
+        ProductOperations baseProduct = new ProductDto();
+        baseProduct.setId("prod-io");
+        product.setId(id);
+        product.setParentId("prod-io");
+        product.setCreatedBy(randomUUID().toString());
+        product.setModifiedBy(randomUUID().toString());
+        EnumMap<PartyRole, ProductRoleInfo> roleMappings = new EnumMap<>(PartyRole.class);
+        for (PartyRole partyRole : PartyRole.values()) {
+            ProductRoleInfo productRoleInfo = new ProductRoleInfo();
+            List<ProductRole> roles = new ArrayList<>();
+            roles.add(mockInstance(new ProductRole(), partyRole.ordinal() + 1));
+            roles.add(mockInstance(new ProductRole(), partyRole.ordinal() + 2));
+            productRoleInfo.setRoles(roles);
+            roleMappings.put(partyRole, productRoleInfo);
+        }
+        product.setRoleMappings(roleMappings);
+        product.setProductOperations(baseProduct);
+
+        // given
+        when(productServiceMock.getProductIsValid(id)).thenReturn(product);
+
+        // when
+        mvc.perform(MockMvcRequestBuilders
+                        .get(BASE_URL + "/{id}/valid", id)
+                        .contentType(APPLICATION_JSON_VALUE)
+                        .accept(APPLICATION_JSON_VALUE))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+
+        // then
+        verify(productServiceMock, times(1))
+                .getProductIsValid(anyString());
+        verifyNoMoreInteractions(productServiceMock);
+    }
+@Test
+    void getProductIsNotValid() throws Exception {
+
+        String id = "prod-io-premium";
+        ProductOperations product = null;
+
+        // given
+        when(productServiceMock.getProductIsValid(id)).thenReturn(product);
+
+        // when
+        mvc.perform(MockMvcRequestBuilders
+                        .get(BASE_URL + "/{id}/valid", id)
+                        .contentType(APPLICATION_JSON_VALUE)
+                        .accept(APPLICATION_JSON_VALUE))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+
+        // then
+        verify(productServiceMock, times(1))
+                .getProductIsValid(anyString());
+        verifyNoMoreInteractions(productServiceMock);
+    }
 
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- added new api to verify if product is valid or not
- added new object as attribute for products that have a base product 

#### Motivation and Context

This API was added in the MS product to avoid code duplication because other micro services (ES. onboarding-backend, external) needed to check whether a product was valid or not.

#### How Has This Been Tested?

the API was called locally under various conditions:

- product with base product both valid
- product with base product, first one valid, second one not
- product with base product, first one not valid, second one valid
- product without base product valid
- product without base product not valid

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.