### PR TITLE
[SELC-3284] feat: added github action to push open api

### DIFF
--- a/.github/workflow/release_open_api.yml
+++ b/.github/workflow/release_open_api.yml
@@ -1,0 +1,29 @@
+name: Swagger Update
+on:
+  pull_request:
+    branches:
+      - release-dev
+    types: [ closed ]
+  workflow_dispatch: #allow to run github action manually
+permissions:
+  contents: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+    - name: Build with Maven
+      run: mvn test -Dtest=SwaggerConfigTest#swaggerSpringPlugin -DfailIfNoTests=false
+    - name: Commit api-docs
+      run: |
+          git ls-files ./app** | grep 'api-docs*' | xargs git add
+          git config --global user.email "selfcare-github@pagopa.it"
+          git config --global user.name "selfcare-github-bot"
+          git commit -m "Update Swagger documentation ${{ github.event.pull_request.title }}" || exit 0
+          git push origin ${{ github.ref_name}}

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -3,14 +3,14 @@ on:
   pull_request:
     branches:
       - release-dev
-    types: [ closed ]
+    types: [ opened ]
   workflow_dispatch: #allow to run github action manually
 permissions:
   contents: write
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
+    #if: github.event.pull_request.merged == true
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK 11
@@ -23,9 +23,8 @@ jobs:
       run: mvn test -Dtest=SwaggerConfigTest#swaggerSpringPlugin -DfailIfNoTests=false
     - name: Commit api-docs
       run: |
-          echo  'PR title: ${{ github.event.pull_request.title }}'
           git ls-files ./app** | grep 'api-docs*' | xargs git add
           git config --global user.email "selfcare-github@pagopa.it"
           git config --global user.name "selfcare-github-bot"
-          git commit -m "Update Swagger documentation ${{ github.event.pull_request.title }}" || exit 0
+          git commit -m "Update Swagger documentation" || exit 0
           git push origin ${{ github.ref_name}}

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -23,7 +23,7 @@ jobs:
       run: mvn test -Dtest=SwaggerConfigTest#swaggerSpringPlugin -DfailIfNoTests=false
     - name: Commit api-docs
       run: |
-          echo  ${{ github.event.pull_request.title }}
+          echo  'PR title: ${{ github.event.pull_request.title }}'
           git ls-files ./app** | grep 'api-docs*' | xargs git add
           git config --global user.email "selfcare-github@pagopa.it"
           git config --global user.name "selfcare-github-bot"

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -23,6 +23,7 @@ jobs:
       run: mvn test -Dtest=SwaggerConfigTest#swaggerSpringPlugin -DfailIfNoTests=false
     - name: Commit api-docs
       run: |
+          echo  ${{ github.event.pull_request.title }}
           git ls-files ./app** | grep 'api-docs*' | xargs git add
           git config --global user.email "selfcare-github@pagopa.it"
           git config --global user.name "selfcare-github-bot"

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -18,6 +18,7 @@ jobs:
       with:
         java-version: '11'
         distribution: 'temurin'
+        cache: maven
     - name: Build with Maven
       run: mvn test -Dtest=SwaggerConfigTest#swaggerSpringPlugin -DfailIfNoTests=false
     - name: Commit api-docs


### PR DESCRIPTION
#### List of Changes

Added github action to push open api after changes in repo

#### Motivation and Context

This development is necessary to avoid situation in which open api does not reflect resouces and code. The scenario happens when objects are changed in repo but not command maven is launched.

#### How Has This Been Tested?

I have run github action opening, from this branch, a new branch in which some swagger properties has been changed.
