### PR TITLE
[SELC-3416] feat: added openapi-diff step to detect breaking changes

### DIFF
--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Check report diff
       run: |
         cd output
-        result=$(grep '<span class="badge badge-Incompatible">Incompatible</span>' api-docs.html)
+        result=$(grep -Po 'badge badge-Incompatible' api-docs.html)
         echo 'test';
         echo $result;
         if [ -s ${result} ];then

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -24,12 +24,12 @@ jobs:
     - name: Check out HEAD revision
       uses: actions/checkout@v2
       with:
-          ref: release-dev
+          ref: ${{ github.head_ref }}
           path: head
     - name: Check out BASE revision
       uses: actions/checkout@v2
       with:
-          ref: ${{ github.head_ref }}
+          ref: release-dev
           path: base
     - name: Build with Maven
       run: mvn test -Dtest=SwaggerConfigTest#swaggerSpringPlugin -DfailIfNoTests=false

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -44,7 +44,6 @@ jobs:
       run: |
         cd output
         result=$(grep -Po 'Incompatible' api-docs.html)
-        echo $result
         if [[ "$result" == *"Incompatible"* ]];then
             exit 1;
         else

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -41,11 +41,13 @@ jobs:
             output_path: ./output
             github_token: ${{ github.token }}
     - name: Check report diff
-      run: |
-        cd output
-        result=$(grep -Po 'Incompatible' api-docs.html)
-        if [ -z $result ]; then
-            core.setFailed('New swagger is different from old one. Action is going to fail!!!!')
+      uses: actions/github-script@v3
+      with:
+          script: |
+            cd output
+            result=$(grep -Po 'Incompatible' api-docs.html)
+            if [ -z $result ]; then
+              core.setFailed('New swagger is different from old one. Action is going to fail!!!!')
     - name: Commit api-docs
       run: |
           #git ls-files ./app** | grep 'api-docs*' | xargs git add

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -40,6 +40,11 @@ jobs:
             base_spec: base/app/src/main/resources/swagger/api-docs.json
             output_path: ./output
             github_token: ${{ github.token }}
+    - name: Debug
+      run: |
+        ls
+        cd output
+        echo "ok"
     - uses: actions/upload-artifact@v2
       with:
           name: diff-reports

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -48,8 +48,7 @@ jobs:
       run: |
         cd output
         echo "test";
-        cat api-docs.html
-        result=$(grep -Po 'Incompatible' api-docs.html)
+        result=$(sed -n '/<span class="badge badge-Incompatible">/,/<\/span>/p'  <file>)
         echo "test2";
         echo $result;
     - name: Commit api-docs

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Check out HEAD revision
       uses: actions/checkout@v2
       with:
-          ref: ${{ github.head_ref }}
+          ref: feature/SELC-3416
           path: head
     - name: Check out BASE revision
       uses: actions/checkout@v2

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         cd output
         echo "test";
-        result=$(sed -n '/<span class="badge badge-Incompatible">/,/<\/span>/p'  <file>)
+        result=$(sed -n '/<span class="badge badge-Incompatible">/,/<\/span>/p'  api-docs.html)
         echo "test2";
         echo $result;
     - name: Commit api-docs

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -45,6 +45,7 @@ jobs:
         cd output
         result=$(grep -Po 'Incompatible' api-docs.html)
         if [ -z $result ]; then
+            echo "::error file={name},line={line},endLine={endLine},title={title}::{message}"
             exit 1
     - name: Commit api-docs
       run: |

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         cd output
         echo "test";
-        result=$(grep -Po 'Incompatible</span>' api-docs.html)
+        result=$(grep -Po '(?<=<class="badge badge-Incompatible">)([^</span>]*)' api-docs.html)
         echo "test2";
         echo $result;
     - name: Commit api-docs

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -49,7 +49,7 @@ jobs:
         cd output
         result=$(grep '<span class="badge badge-Incompatible">Incompatible</span>' api-docs.html)
         echo $result
-        if [ ! -s "${result}" ];then
+        if [ -s "${result}" ];then
             exit 1;
         else
           echo 'No differences between the two api docs';

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -40,17 +40,15 @@ jobs:
             base_spec: base/app/src/main/resources/swagger/api-docs.json
             output_path: ./output
             github_token: ${{ github.token }}
-    - uses: actions/upload-artifact@v2
-      with:
-          name: diff-reports
-          path: ./output
     - name: Check report diff
       run: |
         cd output
-        echo "test";
         result=$(sed -n '/<span class="badge badge-Incompatible">/,/<\/span>/p'  api-docs.html)
-        echo "test2";
-        echo $result;
+        if [ -z $result ]; then
+             exit 1;
+        else
+            echo 'No differences between the two api docs';
+        fi
     - name: Commit api-docs
       run: |
           #git ls-files ./app** | grep 'api-docs*' | xargs git add

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -43,11 +43,11 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
           name: diff-reports
-          path: ${{ runner.temp }}
-    - name: Unzip project
+          path: ./output
+    - name: Unzip artifact
       uses: montudor/action-zip@v1.0.0
       with:
-          args: unzip -qq ${{ runner.temp }}/diff-reports.zip -d ${{ github.workspace }}
+          args: unzip -qq ./output/diff-reports.zip -d ${{ github.workspace }}
     - name: Check report diff
       run: |
           cd ${{ github.workspace }}/diff-reports

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -48,8 +48,8 @@ jobs:
       run: |
         cd output
         result=$(grep -Po '<span class="badge badge-Incompatible">Incompatible</span>' api-docs.html)
-        echo $result;
-        if [[ "$result" == *"Incompatible"* ]];then
+        echo 'test $result'
+        if [[ $result == *"Incompatible"* ]];then
             exit 1;
         else
           echo 'No differences between the two api docs';

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -47,7 +47,7 @@ jobs:
         if [ -z $result ]; then
             echo "DIFF_RESULT=$(echo $result)" >> $GITHUB_ENV
     - name: Label check
-      if: contains(DIFF_RESULT, 'Incompatible')
+      if: contains(env.DIFF_RESULT, 'Incompatible')
       uses: actions/github-script@v3
       with:
           script: |

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -48,9 +48,9 @@ jobs:
       run: |
         cd output
         result=$(grep '<span class="badge badge-Incompatible">Incompatible</span>' api-docs.html)
-        echo 'test'
-        echo $result
-        if [ -s "${result}" ];then
+        echo 'test';
+        echo $result;
+        if [ -s ${result} ];then
             exit 1;
         else
           echo 'No differences between the two api docs';

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -49,7 +49,7 @@ jobs:
         cd output
         result=$(grep -Po '<span class="badge badge-Incompatible">Incompatible</span>' api-docs.html)
         echo $result;
-        if [ -z $result ]; then
+        if [[ $result == *"Incompatible"* ]]; then
           exit 1;
         else
           echo 'No differences between the two api docs';

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -40,6 +40,10 @@ jobs:
             base_spec: base/app/src/main/resources/swagger/api-docs.json
             output_path: ./output
             github_token: ${{ github.token }}
+    - uses: actions/upload-artifact@v2
+      with:
+          name: diff-reports
+          path: ./output
     - name: Check report diff
       run: |
         cd output

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -46,6 +46,8 @@ jobs:
         result=$(grep -Po 'Incompatible' api-docs.html)
         if [ -z $result ]; then
             echo "DIFF_RESULT=$(echo $result)" >> $GITHUB_ENV
+        else
+          echo 'No diff between the two api docs'
     - name: Label check
       if: contains(env.DIFF_RESULT, 'Incompatible')
       uses: actions/github-script@v3

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -40,26 +40,11 @@ jobs:
             base_spec: base/app/src/main/resources/swagger/api-docs.json
             output_path: ./output
             github_token: ${{ github.token }}
-    - name: Debug
-      run: |
-        ls
-        cd output
-        ls
-        result=$(grep -Po 'Incompatible' api-docs.html)
-        echo $result
-    - uses: actions/upload-artifact@v2
-      with:
-          name: diff-reports
-          path: ./output
-    - name: Unzip artifact
-      uses: montudor/action-zip@v1.0.0
-      with:
-          args: unzip -qq diff-reports.zip -d ${{ github.workspace }}
     - name: Check report diff
       run: |
-          cd ${{ github.workspace }}/diff-reports
-          result=$(grep -Po 'Incompatible' api-docs.html)
-          if [ -z $result ]; then
+        cd output
+        result=$(grep -Po 'Incompatible' api-docs.html)
+        if [ -z $result ]; then
             core.setFailed('New swagger is different from old one. Action is going to fail!!!!')
     - name: Commit api-docs
       run: |

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -44,6 +44,12 @@ jobs:
       with:
           name: diff-reports
           path: ./output
+    - name: Check report diff
+      run: |
+          zip -r diff-reports.zip output/
+          result=$(grep -Po 'Incompatible' api-docs.html)
+          if [ -z $result ]; then
+            core.setFailed('New swagger is different from old one. Action is going to fail!!!!')
     - name: Commit api-docs
       run: |
           #git ls-files ./app** | grep 'api-docs*' | xargs git add

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -24,12 +24,12 @@ jobs:
     - name: Check out HEAD revision
       uses: actions/checkout@v2
       with:
-          ref: release-dev
+          ref: ${{ github.head_ref }}
           path: head
     - name: Check out BASE revision
       uses: actions/checkout@v2
       with:
-          ref: ${{ github.head_ref }}
+          ref: release-dev
           path: base
     - name: Build with Maven
       run: mvn test -Dtest=SwaggerConfigTest#swaggerSpringPlugin -DfailIfNoTests=false
@@ -46,8 +46,8 @@ jobs:
       with:
         script: |
           core.setFailed('New swagger is different from old one. Action is going to fail!!!!')
-    #- name: Commit api-docs
-     # run: |
+    - name: Commit api-docs
+      run: |
       #    git ls-files ./app** | grep 'api-docs*' | xargs git add
        #   git config --global user.email "selfcare-github@pagopa.it"
         #  git config --global user.name "selfcare-github-bot"

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -44,10 +44,11 @@ jobs:
       run: |
         cd output
         result=$(grep -Po 'Incompatible' api-docs.html)
+        echo result
         if [ -z $result ]; then
             echo "DIFF_RESULT=$(echo $result)" >> $GITHUB_ENV;
         else
-          echo 'No diff between the two api docs';
+          echo 'No differences between the two api docs';
         fi
     - name: Label check
       if: contains(env.DIFF_RESULT, 'Incompatible')

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -45,8 +45,7 @@ jobs:
         cd output
         result=$(grep -Po 'Incompatible' api-docs.html)
         if [ -z $result ]; then
-            echo 'New swagger is different from old one. Action is going to fail!!!!'
-        exit 1
+            exit 1
     - name: Commit api-docs
       run: |
           #git ls-files ./app** | grep 'api-docs*' | xargs git add

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -44,9 +44,9 @@ jobs:
       run: |
         cd output
         result=$(grep -Po 'Incompatible' api-docs.html)
-        echo result
+        echo $result
         if [ -z $result ]; then
-            echo "DIFF_RESULT=$(echo $result)" >> $GITHUB_ENV;
+            exit 1;
         else
           echo 'No differences between the two api docs';
         fi

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -45,10 +45,10 @@ jobs:
         cd output
         result=$(sed -n '/<span class="badge badge-Incompatible">/,/<\/span>/p'  api-docs.html)
         echo $result;
-        if [ -s "${result}" ]; then
+        if [[ "$result" == *"Incompatible"* ]]; then
              exit 1;
         else
-            echo 'No differences between the two api docs';
+            echo 'No incompatible differences between the two api docs';
         fi
     - name: Commit api-docs
       run: |

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         cd output
         echo "test";
-        result=$(grep -Po '<span class="badge badge-Incompatible">Incompatible</span>' api-docs.html)
+        result=$(grep -Po 'Incompatible' api-docs.html)
         echo "test2";
         echo $result;
     - name: Commit api-docs

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -24,12 +24,12 @@ jobs:
     - name: Check out HEAD revision
       uses: actions/checkout@v2
       with:
-          ref: ${{ github.head_ref }}
+          ref: release-dev
           path: head
     - name: Check out BASE revision
       uses: actions/checkout@v2
       with:
-          ref: release-dev
+          ref: ${{ github.head_ref }}
           path: base
     - name: Build with Maven
       run: mvn test -Dtest=SwaggerConfigTest#swaggerSpringPlugin -DfailIfNoTests=false

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -38,16 +38,19 @@ jobs:
       with:
             head_spec: head/app/src/main/resources/swagger/api-docs.json
             base_spec: base/app/src/main/resources/swagger/api-docs.json
-            output_path: ./output
+            output_path: ${{ runner.temp }}
             github_token: ${{ github.token }}
     - uses: actions/upload-artifact@v2
       with:
           name: diff-reports
-          path: ./output
+          path: ${{ runner.temp }}
+    - name: Unzip project
+      uses: montudor/action-zip@v1.0.0
+      with:
+          args: unzip -qq ${{ runner.temp }}/diff-reports.zip -d ${{ github.workspace }}
     - name: Check report diff
       run: |
-          zip -r diff-reports.zip output/
-          cd /output
+          cd ${{ github.workspace }}/diff-reports
           result=$(grep -Po 'Incompatible' api-docs.html)
           if [ -z $result ]; then
             core.setFailed('New swagger is different from old one. Action is going to fail!!!!')

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -47,8 +47,8 @@ jobs:
     - name: Check report diff
       run: |
         cd output
-        result=$(grep -Po '<span class="badge badge-Incompatible">Incompatible</span>' api-docs.html)
-        echo 'test $result'
+        result=$(grep '<span class="badge badge-Incompatible">Incompatible</span>' api-docs.html)
+        echo $result
         if [[ $result == *"Incompatible"* ]];then
             exit 1;
         else

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Check out HEAD revision
       uses: actions/checkout@v2
       with:
-          ref: feature/SELC-3416
+          ref: ${{ github.head_ref }}
           path: head
     - name: Check out BASE revision
       uses: actions/checkout@v2
@@ -47,11 +47,10 @@ jobs:
     - name: Check report diff
       run: |
         cd output
-        result=$(grep -Po 'badge badge-Incompatible' api-docs.html)
-        echo 'test';
+        result=$(grep -Po '<span class="badge badge-Incompatible">Incompatible</span>' api-docs.html)
         echo $result;
-        if [ -s ${result} ];then
-            exit 1;
+        if [ -z $result ]; then
+          exit 1;
         else
           echo 'No differences between the two api docs';
         fi

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -48,7 +48,8 @@ jobs:
       run: |
         cd output
         echo "test";
-        result=$(grep -Po '(?<=<class="badge badge-Incompatible">)([^</span>]*)' api-docs.html)
+        cat api-docs.html
+        result=$(grep -Po 'Incompatible' api-docs.html)
         echo "test2";
         echo $result;
     - name: Commit api-docs

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -49,7 +49,7 @@ jobs:
         cd output
         result=$(grep -Po '<span class="badge badge-Incompatible">Incompatible</span>' api-docs.html)
         echo $result;
-        if [[ $result == *"Incompatible"* ]]; then
+        if [[ -s "${$result}" ]]; then
           exit 1;
         else
           echo 'No differences between the two api docs';

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -45,8 +45,13 @@ jobs:
         cd output
         result=$(grep -Po 'Incompatible' api-docs.html)
         if [ -z $result ]; then
-            echo "::error file={name},line={line},endLine={endLine},title={title}::{message}"
-            exit 1
+            echo "DIFF_RESULT=$(echo $result)" >> $GITHUB_ENV
+    - name: Label check
+      if: contains($DIFF_RESULT, 'OAS:Incompatible')
+      uses: actions/github-script@v3
+      with:
+          script: |
+            core.setFailed('New swagger is different from old one. Action is going to fail!!!!')
     - name: Commit api-docs
       run: |
           #git ls-files ./app** | grep 'api-docs*' | xargs git add

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -41,13 +41,12 @@ jobs:
             output_path: ./output
             github_token: ${{ github.token }}
     - name: Check report diff
-      uses: actions/github-script@v3
-      with:
-          script: |
-            cd output
-            result=$(grep -Po 'Incompatible' api-docs.html)
-            if [ -z $result ]; then
-              core.setFailed('New swagger is different from old one. Action is going to fail!!!!')
+      run: |
+        cd output
+        result=$(grep -Po 'Incompatible' api-docs.html)
+        if [ -z $result ]; then
+            echo 'New swagger is different from old one. Action is going to fail!!!!'
+        exit 1
     - name: Commit api-docs
       run: |
           #git ls-files ./app** | grep 'api-docs*' | xargs git add

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         cd output
         echo "test";
-        result=$(grep -Po 'Incompatible' api-docs.html)
+        result=$(grep -Po 'Incompatible</span>' api-docs.html)
         echo "test2";
         echo $result;
     - name: Commit api-docs

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -47,7 +47,7 @@ jobs:
         if [ -z $result ]; then
             echo "DIFF_RESULT=$(echo $result)" >> $GITHUB_ENV
     - name: Label check
-      if: contains($DIFF_RESULT, 'OAS:Incompatible')
+      if: contains(DIFF_RESULT, 'Incompatible')
       uses: actions/github-script@v3
       with:
           script: |

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -50,11 +50,6 @@ jobs:
         echo "test";
         result=$(grep -Po '<span class="badge badge-Incompatible">Incompatible</span>' api-docs.html)
         echo $result;
-        #if [[ ! -z "$(cat ${result})" ]]; then
-          #exit 1;
-        #else
-          #echo 'No differences between the two api docs';
-        #fi
     - name: Commit api-docs
       run: |
           #git ls-files ./app** | grep 'api-docs*' | xargs git add

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -45,9 +45,10 @@ jobs:
         cd output
         result=$(grep -Po 'Incompatible' api-docs.html)
         if [ -z $result ]; then
-            echo "DIFF_RESULT=$(echo $result)" >> $GITHUB_ENV
+            echo "DIFF_RESULT=$(echo $result)" >> $GITHUB_ENV;
         else
-          echo 'No diff between the two api docs'
+          echo 'No diff between the two api docs';
+        fi
     - name: Label check
       if: contains(env.DIFF_RESULT, 'Incompatible')
       uses: actions/github-script@v3

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -38,16 +38,16 @@ jobs:
       with:
             head_spec: head/app/src/main/resources/swagger/api-docs.json
             base_spec: base/app/src/main/resources/swagger/api-docs.json
-            output_path: ./output
+            output_path: /output
             github_token: ${{ github.token }}
     - uses: actions/upload-artifact@v2
       with:
           name: diff-reports
-          path: ./output
+          path: /output
     - name: Unzip artifact
       uses: montudor/action-zip@v1.0.0
       with:
-          args: unzip -qq ./output/diff-reports.zip -d ${{ github.workspace }}
+          args: unzip -qq /output/diff-reports.zip -d ${{ github.workspace }}
     - name: Check report diff
       run: |
           cd ${{ github.workspace }}/diff-reports

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -40,15 +40,13 @@ jobs:
             base_spec: base/app/src/main/resources/swagger/api-docs.json
             output_path: ./output
             github_token: ${{ github.token }}
+    - uses: actions/upload-artifact@v2
+      with:
+          name: diff-reports
+          path: ./output
     - name: Commit api-docs
       run: |
-          cd /github/workspace/output
-          result=$(grep -Po 'Incompatible' api-docs.html)
-          if [ -z $NAME ]; then
-            core.setFailed('New swagger is different from old one. Action is going to fail!!!!')
-    - name: Commit api-docs
-      run: |
-          git ls-files ./app** | grep 'api-docs*' | xargs git add
+          #git ls-files ./app** | grep 'api-docs*' | xargs git add
           #git config --global user.email "selfcare-github@pagopa.it"
           #git config --global user.name "selfcare-github-bot"
           #git commit -m "Update Swagger documentation" || exit 0

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -44,7 +44,9 @@ jobs:
       run: |
         ls
         cd output
-        echo "ok"
+        ls
+        result=$(grep -Po 'Incompatible' api-docs.html)
+        echo $result
     - uses: actions/upload-artifact@v2
       with:
           name: diff-reports

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -48,6 +48,7 @@ jobs:
       run: |
         cd output
         result=$(grep '<span class="badge badge-Incompatible">Incompatible</span>' api-docs.html)
+        echo 'test'
         echo $result
         if [ -s "${result}" ];then
             exit 1;

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -38,16 +38,16 @@ jobs:
       with:
             head_spec: head/app/src/main/resources/swagger/api-docs.json
             base_spec: base/app/src/main/resources/swagger/api-docs.json
-            output_path: /output
+            output_path: ./output
             github_token: ${{ github.token }}
     - uses: actions/upload-artifact@v2
       with:
           name: diff-reports
-          path: /output
+          path: ./output
     - name: Unzip artifact
       uses: montudor/action-zip@v1.0.0
       with:
-          args: unzip -qq /output/diff-reports.zip -d ${{ github.workspace }}
+          args: unzip -qq diff-reports.zip -d ${{ github.workspace }}
     - name: Check report diff
       run: |
           cd ${{ github.workspace }}/diff-reports

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Check out HEAD revision
       uses: actions/checkout@v2
       with:
-          ref: feature/SELC-3416
+          ref: ${{ github.head_ref }}
           path: head
     - name: Check out BASE revision
       uses: actions/checkout@v2

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -40,20 +40,16 @@ jobs:
             base_spec: base/app/src/main/resources/swagger/api-docs.json
             output_path: ./output
             github_token: ${{ github.token }}
-    - uses: actions/upload-artifact@v2
-      with:
-          name: diff-reports
-          path: ./output
-    - name: Label check
-      if: contains(github.event.pull_request.labels.*.name, 'OAS:Incompatible')
-      uses: actions/github-script@v3
-      with:
-        script: |
-          core.setFailed('New swagger is different from old one. Action is going to fail!!!!')
+    - name: Commit api-docs
+      run: |
+          cd /github/workspace/output
+          result=$(grep -Po 'Incompatible' api-docs.html)
+          if [ -z $NAME ]; then
+            core.setFailed('New swagger is different from old one. Action is going to fail!!!!')
     - name: Commit api-docs
       run: |
           git ls-files ./app** | grep 'api-docs*' | xargs git add
-          git config --global user.email "selfcare-github@pagopa.it"
-          git config --global user.name "selfcare-github-bot"
-          git commit -m "Update Swagger documentation" || exit 0
-          git push origin ${{ github.ref_name}}
+          #git config --global user.email "selfcare-github@pagopa.it"
+          #git config --global user.name "selfcare-github-bot"
+          #git commit -m "Update Swagger documentation" || exit 0
+          #git push origin ${{ github.ref_name}}

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -47,6 +47,7 @@ jobs:
     - name: Check report diff
       run: |
           zip -r diff-reports.zip output/
+          cd /output
           result=$(grep -Po 'Incompatible' api-docs.html)
           if [ -z $result ]; then
             core.setFailed('New swagger is different from old one. Action is going to fail!!!!')

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -47,7 +47,8 @@ jobs:
     - name: Check report diff
       run: |
         cd output
-        result=$(grep -Po 'Incompatible' api-docs.html)
+        result=''
+        result=$(grep -Po '<span class="badge badge-Incompatible">Incompatible</span>' api-docs.html)
         echo $result;
         if [[ "$result" == *"Incompatible"* ]];then
             exit 1;

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -40,6 +40,10 @@ jobs:
             base_spec: base/app/src/main/resources/swagger/api-docs.json
             output_path: ./output
             github_token: ${{ github.token }}
+    - uses: actions/upload-artifact@v2
+      with:
+          name: diff-reports
+          path: ./output
     - name: Label check
       if: contains(github.event.pull_request.labels.*.name, 'OAS:Incompatible')
       uses: actions/github-script@v3
@@ -48,8 +52,8 @@ jobs:
           core.setFailed('New swagger is different from old one. Action is going to fail!!!!')
     - name: Commit api-docs
       run: |
-      #    git ls-files ./app** | grep 'api-docs*' | xargs git add
-       #   git config --global user.email "selfcare-github@pagopa.it"
-        #  git config --global user.name "selfcare-github-bot"
-         # git commit -m "Update Swagger documentation" || exit 0
-          #git push origin ${{ github.ref_name}}
+          git ls-files ./app** | grep 'api-docs*' | xargs git add
+          git config --global user.email "selfcare-github@pagopa.it"
+          git config --global user.name "selfcare-github-bot"
+          git commit -m "Update Swagger documentation" || exit 0
+          git push origin ${{ github.ref_name}}

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -45,17 +45,11 @@ jobs:
         cd output
         result=$(grep -Po 'Incompatible' api-docs.html)
         echo $result
-        if [ -z $result ]; then
+        if [[ "$result" == *"Incompatible"* ]];then
             exit 1;
         else
           echo 'No differences between the two api docs';
         fi
-    - name: Label check
-      if: contains(env.DIFF_RESULT, 'Incompatible')
-      uses: actions/github-script@v3
-      with:
-          script: |
-            core.setFailed('New swagger is different from old one. Action is going to fail!!!!')
     - name: Commit api-docs
       run: |
           #git ls-files ./app** | grep 'api-docs*' | xargs git add

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -47,7 +47,6 @@ jobs:
     - name: Check report diff
       run: |
         cd output
-        result=''
         result=$(grep -Po '<span class="badge badge-Incompatible">Incompatible</span>' api-docs.html)
         echo $result;
         if [[ "$result" == *"Incompatible"* ]];then

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -38,7 +38,7 @@ jobs:
       with:
             head_spec: head/app/src/main/resources/swagger/api-docs.json
             base_spec: base/app/src/main/resources/swagger/api-docs.json
-            output_path: ${{ runner.temp }}
+            output_path: ./output
             github_token: ${{ github.token }}
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -49,6 +49,7 @@ jobs:
         cd output
         echo "test";
         result=$(grep -Po '<span class="badge badge-Incompatible">Incompatible</span>' api-docs.html)
+        echo "test2";
         echo $result;
     - name: Commit api-docs
       run: |

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -3,8 +3,7 @@ on:
   pull_request:
     branches:
       - release-dev
-      - feature/SELC-3416
-    types: [ opened, reopened ]
+    types: [ opened ]
   workflow_dispatch: #allow to run github action manually
 permissions:
   contents: write
@@ -52,8 +51,8 @@ jobs:
         fi
     - name: Commit api-docs
       run: |
-          #git ls-files ./app** | grep 'api-docs*' | xargs git add
-          #git config --global user.email "selfcare-github@pagopa.it"
-          #git config --global user.name "selfcare-github-bot"
-          #git commit -m "Update Swagger documentation" || exit 0
-          #git push origin ${{ github.ref_name}}
+          git ls-files ./app** | grep 'api-docs*' | xargs git add
+          git config --global user.email "selfcare-github@pagopa.it"
+          git config --global user.name "selfcare-github-bot"
+          git commit -m "Update Swagger documentation" || exit 0
+          git push origin ${{ github.ref_name}}

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -47,9 +47,10 @@ jobs:
     - name: Check report diff
       run: |
         cd output
+        echo "test";
         result=$(grep -Po '<span class="badge badge-Incompatible">Incompatible</span>' api-docs.html)
         echo $result;
-        if [[ -s "${$result}" ]]; then
+        if [[ ! -z "$(cat ${result})" ]]; then
           exit 1;
         else
           echo 'No differences between the two api docs';

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -50,11 +50,11 @@ jobs:
         echo "test";
         result=$(grep -Po '<span class="badge badge-Incompatible">Incompatible</span>' api-docs.html)
         echo $result;
-        if [[ ! -z "$(cat ${result})" ]]; then
-          exit 1;
-        else
-          echo 'No differences between the two api docs';
-        fi
+        #if [[ ! -z "$(cat ${result})" ]]; then
+          #exit 1;
+        #else
+          #echo 'No differences between the two api docs';
+        #fi
     - name: Commit api-docs
       run: |
           #git ls-files ./app** | grep 'api-docs*' | xargs git add

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Check out HEAD revision
       uses: actions/checkout@v2
       with:
-          ref: ${{ github.head_ref }}
+          ref: feature/SELC-3416
           path: head
     - name: Check out BASE revision
       uses: actions/checkout@v2
@@ -44,6 +44,7 @@ jobs:
       run: |
         cd output
         result=$(grep -Po 'Incompatible' api-docs.html)
+        echo $result;
         if [[ "$result" == *"Incompatible"* ]];then
             exit 1;
         else

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -49,7 +49,7 @@ jobs:
         cd output
         result=$(grep '<span class="badge badge-Incompatible">Incompatible</span>' api-docs.html)
         echo $result
-        if [[ $result == *"Incompatible"* ]];then
+        if [ ! -s "${result}" ];then
             exit 1;
         else
           echo 'No differences between the two api docs';

--- a/.github/workflows/release_open_api.yml
+++ b/.github/workflows/release_open_api.yml
@@ -44,7 +44,8 @@ jobs:
       run: |
         cd output
         result=$(sed -n '/<span class="badge badge-Incompatible">/,/<\/span>/p'  api-docs.html)
-        if [ -z $result ]; then
+        echo $result;
+        if [ -s "${result}" ]; then
              exit 1;
         else
             echo 'No differences between the two api docs';

--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -1362,11 +1362,6 @@
             "description" : "Product's status",
             "enum" : [ "ACTIVE", "INACTIVE", "PHASE_OUT", "TESTING" ]
           },
-          "test" : {
-            "type" : "boolean",
-            "description" : "If a product is invoiceable",
-            "example" : false
-          },
           "title" : {
             "type" : "string",
             "description" : "Product's title"

--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -1346,7 +1346,7 @@
           "productOperations" : {
             "$ref" : "#/components/schemas/ProductOperations"
           },
-          "roleManagementURL" : {
+          "roleManagementURLs" : {
             "type" : "string",
             "description" : "Url of the utilities management"
           },
@@ -1361,11 +1361,6 @@
             "type" : "string",
             "description" : "Product's status",
             "enum" : [ "ACTIVE", "INACTIVE", "PHASE_OUT", "TESTING" ]
-          },
-          "test" : {
-            "type" : "boolean",
-            "description" : "If a product is invoiceable",
-            "example" : false
           },
           "title" : {
             "type" : "string",

--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -1346,6 +1346,10 @@
           "productOperations" : {
             "$ref" : "#/components/schemas/ProductOperations"
           },
+          "roleManagementURL" : {
+            "type" : "string",
+            "description" : "Url of the utilities management"
+          },
           "roleMappings" : {
             "type" : "object",
             "additionalProperties" : {

--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -1346,7 +1346,7 @@
           "productOperations" : {
             "$ref" : "#/components/schemas/ProductOperations"
           },
-          "roleManagementURLs" : {
+          "roleManagementURL" : {
             "type" : "string",
             "description" : "Url of the utilities management"
           },

--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -1346,10 +1346,6 @@
           "productOperations" : {
             "$ref" : "#/components/schemas/ProductOperations"
           },
-          "roleManagementURL" : {
-            "type" : "string",
-            "description" : "Url of the utilities management"
-          },
           "roleMappings" : {
             "type" : "object",
             "additionalProperties" : {
@@ -1361,6 +1357,11 @@
             "type" : "string",
             "description" : "Product's status",
             "enum" : [ "ACTIVE", "INACTIVE", "PHASE_OUT", "TESTING" ]
+          },
+          "test" : {
+            "type" : "boolean",
+            "description" : "If a product is invoiceable",
+            "example" : false
           },
           "title" : {
             "type" : "string",

--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -1346,7 +1346,7 @@
           "productOperations" : {
             "$ref" : "#/components/schemas/ProductOperations"
           },
-          "roleManagementURL" : {
+          "roleManagementURLs" : {
             "type" : "string",
             "description" : "Url of the utilities management"
           },

--- a/web/src/main/java/it/pagopa/selfcare/product/web/model/ProductResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/product/web/model/ProductResource.java
@@ -78,7 +78,7 @@ public class ProductResource {
     private Map<String, BackOfficeConfigurationsResource> backOfficeEnvironmentConfigurations;
 
     @ApiModelProperty(value = "${swagger.product.model.roleManagementURL}")
-    private String roleManagementURL;
+    private String roleManagementURLs;
 
     private ProductOperations productOperations;
 

--- a/web/src/main/java/it/pagopa/selfcare/product/web/model/ProductResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/product/web/model/ProductResource.java
@@ -84,4 +84,7 @@ public class ProductResource {
 
     @ApiModelProperty(value = "${swagger.product.model.invoiceable}")
     private boolean invoiceable;
+
+    @ApiModelProperty(value = "${swagger.product.model.invoiceable}")
+    private boolean test;
 }

--- a/web/src/main/java/it/pagopa/selfcare/product/web/model/ProductResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/product/web/model/ProductResource.java
@@ -78,7 +78,7 @@ public class ProductResource {
     private Map<String, BackOfficeConfigurationsResource> backOfficeEnvironmentConfigurations;
 
     @ApiModelProperty(value = "${swagger.product.model.roleManagementURL}")
-    private String roleManagementURLs;
+    private String roleManagementURL;
 
     private ProductOperations productOperations;
 

--- a/web/src/main/java/it/pagopa/selfcare/product/web/model/ProductResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/product/web/model/ProductResource.java
@@ -84,7 +84,4 @@ public class ProductResource {
 
     @ApiModelProperty(value = "${swagger.product.model.invoiceable}")
     private boolean invoiceable;
-
-    @ApiModelProperty(value = "${swagger.product.model.invoiceable}")
-    private boolean test;
 }

--- a/web/src/main/java/it/pagopa/selfcare/product/web/model/ProductResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/product/web/model/ProductResource.java
@@ -77,11 +77,11 @@ public class ProductResource {
     @ApiModelProperty(value = "${swagger.product.model.backOfficeEnvironmentConfigurations}")
     private Map<String, BackOfficeConfigurationsResource> backOfficeEnvironmentConfigurations;
 
-    @ApiModelProperty(value = "${swagger.product.model.roleManagementURL}")
-    private String roleManagementURL;
-
     private ProductOperations productOperations;
 
     @ApiModelProperty(value = "${swagger.product.model.invoiceable}")
     private boolean invoiceable;
+
+    @ApiModelProperty(value = "${swagger.product.model.invoiceable}")
+    private boolean test;
 }

--- a/web/src/main/java/it/pagopa/selfcare/product/web/model/ProductResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/product/web/model/ProductResource.java
@@ -78,13 +78,10 @@ public class ProductResource {
     private Map<String, BackOfficeConfigurationsResource> backOfficeEnvironmentConfigurations;
 
     @ApiModelProperty(value = "${swagger.product.model.roleManagementURL}")
-    private String roleManagementURL;
+    private String roleManagementURLs;
 
     private ProductOperations productOperations;
 
     @ApiModelProperty(value = "${swagger.product.model.invoiceable}")
     private boolean invoiceable;
-
-    @ApiModelProperty(value = "${swagger.product.model.invoiceable}")
-    private boolean test;
 }

--- a/web/src/main/java/it/pagopa/selfcare/product/web/model/ProductResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/product/web/model/ProductResource.java
@@ -85,6 +85,4 @@ public class ProductResource {
     @ApiModelProperty(value = "${swagger.product.model.invoiceable}")
     private boolean invoiceable;
 
-    @ApiModelProperty(value = "${swagger.product.model.invoiceable}")
-    private boolean test;
 }

--- a/web/src/main/java/it/pagopa/selfcare/product/web/model/ProductResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/product/web/model/ProductResource.java
@@ -77,6 +77,9 @@ public class ProductResource {
     @ApiModelProperty(value = "${swagger.product.model.backOfficeEnvironmentConfigurations}")
     private Map<String, BackOfficeConfigurationsResource> backOfficeEnvironmentConfigurations;
 
+    @ApiModelProperty(value = "${swagger.product.model.roleManagementURL}")
+    private String roleManagementURL;
+
     private ProductOperations productOperations;
 
     @ApiModelProperty(value = "${swagger.product.model.invoiceable}")


### PR DESCRIPTION
#### List of Changes

Added openapi-diff step into Github action to detect breaking changes.

#### Motivation and Context

In order to detect incompatible changes between the branch of release-dev and the branch of any new developmen, it has been added into githib action a step that check differences between the two open api. In particular:

- The step will cause the failure of github action in case of deletion of attribute from resources
- The step will cause the failure of github action in case of renaming of attribute from resources
- No failure in case of new attribute added in resources
