### PR TITLE
[SELC-3460] feat: added tag external-v2 for automatic generation of open-api

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -218,7 +218,7 @@
     },
     "/products/{id}" : {
       "get" : {
-        "tags" : [ "product" ],
+        "tags" : [ "external-v2" ],
         "summary" : "getProduct",
         "description" : "Service that returns the information for a single product given its product id",
         "operationId" : "getProductUsingGET",

--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -218,7 +218,7 @@
     },
     "/products/{id}" : {
       "get" : {
-        "tags" : [ "external-v2" ],
+        "tags" : [ "external-v2", "product" ],
         "summary" : "getProduct",
         "description" : "Service that returns the information for a single product given its product id",
         "operationId" : "getProductUsingGET",

--- a/web/src/main/java/it/pagopa/selfcare/product/web/controller/ProductController.java
+++ b/web/src/main/java/it/pagopa/selfcare/product/web/controller/ProductController.java
@@ -4,6 +4,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
 import it.pagopa.selfcare.commons.base.utils.InstitutionType;
 import it.pagopa.selfcare.product.connector.model.PartyRole;
 import it.pagopa.selfcare.product.connector.model.ProductOperations;
@@ -99,7 +100,7 @@ public class ProductController {
         return ResponseEntity.ok().build();
     }
 
-    @Tag(name = "external-v2")
+    @Tags({@Tag(name = "product"), @Tag(name = "external-v2")})
     @GetMapping("/{id}")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.product.operation.getProduct}")
@@ -234,6 +235,7 @@ public class ProductController {
         productService.deleteProduct(id);
         log.trace("deleteProduct end");
     }
+
     @GetMapping("/{id}/valid")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.product.operation.getProduct}")

--- a/web/src/main/java/it/pagopa/selfcare/product/web/controller/ProductController.java
+++ b/web/src/main/java/it/pagopa/selfcare/product/web/controller/ProductController.java
@@ -3,6 +3,7 @@ package it.pagopa.selfcare.product.web.controller;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import it.pagopa.selfcare.commons.base.utils.InstitutionType;
 import it.pagopa.selfcare.product.connector.model.PartyRole;
 import it.pagopa.selfcare.product.connector.model.ProductOperations;
@@ -98,7 +99,7 @@ public class ProductController {
         return ResponseEntity.ok().build();
     }
 
-
+    @Tag(name = "external-v2")
     @GetMapping("/{id}")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.product.operation.getProduct}")


### PR DESCRIPTION
#### List of Changes

Added new tag **external-v2** for operation that will be include into open-api for APIM

#### Motivation and Context

In order to avoid manual construction of open-api for APIM, all operations that will be included into this document are tagged with **external-v2** or **support**. In this way, a step of github action will scan them and automatically include into open-api.